### PR TITLE
Added exception handling and result checking

### DIFF
--- a/src/Lodge/Postcode/Postcode.php
+++ b/src/Lodge/Postcode/Postcode.php
@@ -9,25 +9,79 @@ class Postcode {
 
 		// Retrieve the latitude and longitude
 		$url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . $search_code . '&sensor=false';
-		$json = json_decode(file_get_contents($url));
-		$lat = $json->results[0]->geometry->location->lat;
-		$lng = $json->results[0]->geometry->location->lng;
 
-		return array(
-			'latitude'  => $lat,
-			'longitude' => $lng
-		);
+        // If Google Maps API fails, catch it and throw a better error
+        try
+        {
+            $json = json_decode(file_get_contents($url));
+        }
+        catch(\Exception $e)
+        {
+            throw new ServiceUnavailableException;
+        }
+
+        if(!empty($json->results))
+        {
+            $lat = $json->results[0]->geometry->location->lat;
+            $lng = $json->results[0]->geometry->location->lng;
+
+    		return array(
+	    		'latitude'  => $lat,
+		    	'longitude' => $lng
+		    );
+        }
+
+        // We must have nothing if we've got here
+        return array();
+
 	}
 
+    public function mutatePostcode($postcode)
+    {
+        // Ensure the postcode is all upper case with no spaces
+        return preg_replace('/ /', '', strtoupper($postcode));
+    }
+
 	public function lookup($postcode)
-	{
+    {
+        // Mutate the postcode
+        $postcode = $this->mutatePostcode($postcode);
+
 		// Sanitize the postcode:
 		$coords = $this->getCoordinates($postcode);
+
+        // If empty, we must have no results
+        if(empty($coords))
+            return array();
 
 		// A second call will now retrieve the address
 		$address_url  = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' . $coords['latitude'] . ',' . $coords['longitude'] . '&sensor=false';
 		$address_json = json_decode(file_get_contents($address_url));
-		$address_data = $address_json->results[0]->address_components;
+
+        // The correct result is not always the first one, so loop through results here
+        foreach($address_json->results as $current_address)
+        {
+            foreach($current_address->address_components as $component)
+            {
+                // If this address_component is a postcode and matches...
+                if(array_search('postal_code', $component->types) !== FALSE &&
+                   $postcode == $this->mutatePostcode($component->long_name))
+                {
+                    $address_data = $current_address->address_components;
+                }
+            }
+        }
+
+        // If no exact match found, use the first as a closest option
+        if(!isset($address_data) &&
+           !empty($address_json->results))
+        {
+            $address_data = $address_json->results[0]->address_components;
+        }
+
+        // If still nothing, return empty array
+        if(!isset($address_data))
+            return array();
 
 		// Initialize all values as empty
 		$street_number = '';

--- a/src/Lodge/Postcode/ServiceUnavailableException.php
+++ b/src/Lodge/Postcode/ServiceUnavailableException.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Lodge\Postcode;
+
+use RuntimeException;
+
+class ServiceUnavailableException extends RuntimeException
+{
+    protected $message = 'The service could not be contacted. Please try again.';
+    protected $code = 503;
+}


### PR DESCRIPTION
- Added exception and result handling to getCoordinates
- Added result checking - using the first is a mistake

Exception handler/rethrower on file_get_contents avoids having to handle generic 500
exceptions at a high level. The new exception, ServiceUnavailableException will be
rethrown on any error.

Result checking is also necessary, as the first result of the latitude/longitude search
is often incorrect for rural areas. It now loops through the results, trying to find one
that has a matching postal_code. If none is found, the library will return an empty array.
