### PR TITLE
Google API Key

### DIFF
--- a/src/Lodge/Postcode/Postcode.php
+++ b/src/Lodge/Postcode/Postcode.php
@@ -13,7 +13,7 @@ class Postcode {
 		// If Google Maps API fails, catch it and throw a better error
 		try
 		{
-			$json = json_decode(file_get_contents($url));
+			$json = $this->callGoogleApi($url);
 		}
 		catch(\Exception $e)
 		{
@@ -55,7 +55,8 @@ class Postcode {
 
 		// A second call will now retrieve the address
 		$address_url  = 'https://maps.googleapis.com/maps/api/geocode/json?latlng=' . $coords['latitude'] . ',' . $coords['longitude'] . '&sensor=false';
-		$address_json = json_decode(file_get_contents($address_url));
+
+		$address_json = $this->callGoogleApi($address_url);
 
 		// The correct result is not always the first one, so loop through results here
 		foreach($address_json->results as $current_address)
@@ -135,5 +136,26 @@ class Postcode {
 
 		return $array;
 	}
+
+    private function callGoogleApi($url) 
+    {
+        $url = $this->addApiKeyToUrl($url);
+        $json = json_decode(file_get_contents($url));
+        $this->checkApiError($json);
+        return $json;
+    }
+
+    private function addApiKeyToUrl($url)
+    {
+        return ($api_key = \Config::get('postcode-lookup::apikey')) ?
+            $url . $api_key :
+            $url;
+    }
+    
+    private function checkApiError($json)
+    {
+        if (property_exists($json, 'error_message'))
+            throw new ServiceUnavailableException($json->error_message);
+    }
 
 }

--- a/src/Lodge/Postcode/Postcode.php
+++ b/src/Lodge/Postcode/Postcode.php
@@ -148,7 +148,7 @@ class Postcode {
     private function addApiKeyToUrl($url)
     {
         return ($api_key = \Config::get('postcode-lookup::apikey')) ?
-            $url . $api_key :
+            $url . '&key=' . $api_key :
             $url;
     }
     

--- a/src/Lodge/Postcode/Postcode.php
+++ b/src/Lodge/Postcode/Postcode.php
@@ -10,16 +10,8 @@ class Postcode {
 		// Retrieve the latitude and longitude
 		$url = 'https://maps.googleapis.com/maps/api/geocode/json?address=' . $search_code . '&sensor=false';
 
-		// If Google Maps API fails, catch it and throw a better error
-		try
-		{
-			$json = $this->callGoogleApi($url);
-		}
-		catch(\Exception $e)
-		{
-			throw new ServiceUnavailableException;
-		}
-
+		$json = $this->callGoogleApi($url);
+		
 		if(!empty($json->results))
 		{
 			$lat = $json->results[0]->geometry->location->lat;

--- a/src/Lodge/Postcode/PostcodeServiceProvider.php
+++ b/src/Lodge/Postcode/PostcodeServiceProvider.php
@@ -35,6 +35,8 @@ class PostcodeServiceProvider extends ServiceProvider
         $this->app->singleton('postcode', function () {
             return new Postcode();
         });
+        
+        \Config::package('lodge/postcode-lookup','postcode');
     }
 
     /**

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -1,0 +1,16 @@
+<?php
+
+return array(
+    /*
+  	|--------------------------------------------------------------------------
+  	| API Key
+  	|--------------------------------------------------------------------------
+  	|
+	  | The api key provided by Google. If you don't know your API key
+	  | you can generate one here for Google Maps Geocoding API:
+	  | "https://console.developers.google.com/apis/credentials"
+	  |
+	  */
+    
+    'apikey' => null
+);

--- a/src/config/config.php
+++ b/src/config/config.php
@@ -2,15 +2,15 @@
 
 return array(
     /*
-  	|--------------------------------------------------------------------------
-  	| API Key
-  	|--------------------------------------------------------------------------
-  	|
-	  | The api key provided by Google. If you don't know your API key
-	  | you can generate one here for Google Maps Geocoding API:
-	  | "https://console.developers.google.com/apis/credentials"
-	  |
-	  */
+    |--------------------------------------------------------------------------
+    | API Key
+    |--------------------------------------------------------------------------
+    |
+    | The api key provided by Google. If you don't know your API key
+    | you can generate one here for Google Maps Geocoding API:
+    | "https://console.developers.google.com/apis/credentials"
+    |
+    */
     
     'apikey' => null
 );


### PR DESCRIPTION
Without a Google API Key it is very easy to reach the google api quota limits.

The changes include reporting this error rather than just returning a blank array.

It also includes an api key in the google api calls if it has been set in the config file.